### PR TITLE
Tuning 'manifest.json' for both platforms

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -18,7 +18,7 @@
     "128": "dist/img/favicon/favicon-128x128.png"
   },
   "browser_action": {
-    "default_title": "RESTED",
+    "default_title": "Open RESTED tab",
     "default_icon": {
       "16": "dist/img/favicon/favicon-16x16.png",
       "32": "dist/img/favicon/favicon-32x32.png",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -3,12 +3,6 @@
   "version": "2.1.1",
   "description": "A REST client for the rest of us",
   "homepage_url": "https://github.com/esphen/RESTED",
-  "contributors": [
-    "Espen Henriksen",
-    "Mostafa Mirmousavi",
-    "Tibor Katelbach"
-  ],
-  "license": "GPL-2.0",
   "manifest_version": 2,
   "applications": {
     "gecko": {

--- a/google-chrome/manifest.json
+++ b/google-chrome/manifest.json
@@ -4,6 +4,7 @@
   "description": "A REST client for the rest of us",
   "homepage_url": "https://github.com/esphen/RESTED",
   "manifest_version": 2,
+  "minimum_chrome_version": "60.0",
   "icons": {
     "16": "dist/img/favicon/favicon-16x16.png",
     "32": "dist/img/favicon/favicon-32x32.png",
@@ -12,7 +13,7 @@
     "128": "dist/img/favicon/favicon-128x128.png"
   },
   "browser_action": {
-    "default_title": "RESTED",
+    "default_title": "Open RESTED tab",
     "default_icon": {
       "16": "dist/img/favicon/favicon-16x16.png",
       "32": "dist/img/favicon/favicon-32x32.png",


### PR DESCRIPTION
I've found some problems in `manifest.json`: [#2](https://github.com/gear54rus/RESTED-APS/issues/2).

I've cherry-picked some commits on the branch created from your `next` and then fixed merge conflicts and accounted for differences between our extension. All my future pull requests will use this scheme, and I would like some input from you, @esphen about this scheme. Perhaps you can suggest some better collaboration scheme between our projects.

Thanks!