### PR TITLE
Options modal UI updates

### DIFF
--- a/src/components/Fonticon/StyledComponents.js
+++ b/src/components/Fonticon/StyledComponents.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+import { Clearfix } from 'react-bootstrap';
+
+// eslint-disable-next-line import/prefer-default-export
+export const StyledFonticon = styled(Clearfix)`
+  & {
+    display: inline-block;
+  }
+  i {
+    margin-right: 2px;
+  }
+`;
+

--- a/src/components/Fonticon/index.js
+++ b/src/components/Fonticon/index.js
@@ -1,12 +1,16 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
+import { StyledFonticon } from './StyledComponents';
+
 function Fonticon({ icon, className }) {
   return (
-    <i
-      className={classNames('fa', `fa-${icon}`, className)}
-      role="presentation"
-    />
+    <StyledFonticon>
+      <i
+        className={classNames('fa', `fa-${icon}`, className)}
+        role="presentation"
+      />
+    </StyledFonticon>
   );
 }
 

--- a/src/components/OptionsModal/GeneralOptionsPane.js
+++ b/src/components/OptionsModal/GeneralOptionsPane.js
@@ -9,6 +9,12 @@ import { THEMES, HIGHLIGHT_STYLES, DEFAULT_HISTORY_SIZE } from 'constants/consta
 
 import { StyledGeneralOptions } from './StyledComponents';
 
+const CodeHighlightPreviewText = `{
+    example: "json",
+    soThatYouCan: 7357,
+    your: "HIGHLIGHT_STYLE"
+}`;
+
 function GeneralOptionsPane({ options, updateOption }) {
   return (
     <StyledGeneralOptions>
@@ -58,21 +64,8 @@ function GeneralOptionsPane({ options, updateOption }) {
                       </option>
                     ))}
                   </FormControl>
-                </FormGroup>
-              </td>
-            </tr>
-
-            <tr>
-              <td>
-                <FormGroup>
                   <Highlight className="json">
-                    {`
-              {
-                example: "json",
-                soThatYouCan: 7357,
-                your: "HIGHLIGHT_STYLE"
-              }
-                    `}
+                    {CodeHighlightPreviewText}
                   </Highlight>
                 </FormGroup>
               </td>

--- a/src/components/OptionsModal/GeneralOptionsPane.js
+++ b/src/components/OptionsModal/GeneralOptionsPane.js
@@ -90,67 +90,72 @@ function GeneralOptionsPane({ options, updateOption }) {
 
             <tr>
               <td>
-                <Checkbox
-                  checked={options.get('disableHighlighting', false)}
-                  onChange={e => {
-                    updateOption('disableHighlighting', e.target.checked);
-                  }}
-                >
-                  Disable highlight styles
-                  <p>
-                    If you struggle with performance on large responses,
-                    disabling hightlight styles may help
-                  </p>
-                </Checkbox>
-                <Checkbox
-                  checked={options.get('wrapResponse', false)}
-                  onChange={e => {
-                    updateOption('wrapResponse', e.target.checked);
-                  }}
-                >
-                  Wrap response
-                  <p>
-                    Wrap the lines of the response automatically when it
-                    overflows the box. Enabling this will ensure you don&apos;t
-                    need to scroll left/right
-                  </p>
-                </Checkbox>
-                <Checkbox
-                  checked={options.get('defaultCompact', false)}
-                  onChange={e => {
-                    updateOption('defaultCompact', e.target.checked);
-                  }}
-                >
-                  Compact mode
-                  <p>
-                    Sets the default view on load for requests in collections to
-                    compact. Useful if you have large collections, especially if
-                    you use named requests
-                  </p>
-                </Checkbox>
-                <Checkbox
-                  checked={options.get('headerDescriptionEnabled', true)}
-                  onChange={e => {
-                    updateOption('headerDescriptionEnabled', e.target.checked);
-                  }}
-                >
-                  Show header descriptions
-                  <p>
-                    Displays a short description of each header below each
-                    search suggestion
-                  </p>
-                </Checkbox>
-                <Checkbox
-                  checked={options.get('ignoreCache', false)}
-                  onChange={e => {
-                    updateOption('ignoreCache', e.target.checked);
-                  }}
-                >
-                  Ignore cache
-                  <p>
-                    Force all requests to ignore the browser cache
-                  </p>
-                </Checkbox>
+                <FormGroup>
+                  <ControlLabel>
+                    Miscellaneous
+                  </ControlLabel>
+                  <Checkbox
+                    checked={options.get('disableHighlighting', false)}
+                    onChange={e => {
+                      updateOption('disableHighlighting', e.target.checked);
+                    }}
+                  >
+                    Disable highlight styles
+                    <p>
+                      If you struggle with performance on large responses,
+                      disabling hightlight styles may help
+                    </p>
+                  </Checkbox>
+                  <Checkbox
+                    checked={options.get('wrapResponse', false)}
+                    onChange={e => {
+                      updateOption('wrapResponse', e.target.checked);
+                    }}
+                  >
+                    Wrap response
+                    <p>
+                      Wrap the lines of the response automatically when it
+                      overflows the box. Enabling this will ensure you don&apos;t
+                      need to scroll left/right
+                    </p>
+                  </Checkbox>
+                  <Checkbox
+                    checked={options.get('defaultCompact', false)}
+                    onChange={e => {
+                      updateOption('defaultCompact', e.target.checked);
+                    }}
+                  >
+                    Compact mode
+                    <p>
+                      Sets the default view on load for requests in collections to
+                      compact. Useful if you have large collections, especially if
+                      you use named requests
+                    </p>
+                  </Checkbox>
+                  <Checkbox
+                    checked={options.get('headerDescriptionEnabled', true)}
+                    onChange={e => {
+                      updateOption('headerDescriptionEnabled', e.target.checked);
+                    }}
+                  >
+                    Show header descriptions
+                    <p>
+                      Displays a short description of each header below each
+                      search suggestion
+                    </p>
+                  </Checkbox>
+                  <Checkbox
+                    checked={options.get('ignoreCache', false)}
+                    onChange={e => {
+                      updateOption('ignoreCache', e.target.checked);
+                    }}
+                  >
+                    Ignore cache
+                    <p>
+                      Force all requests to ignore the browser cache
+                    </p>
+                  </Checkbox>
+                </FormGroup>
               </td>
             </tr>
           </tbody>

--- a/src/components/OptionsModal/SyncPane.js
+++ b/src/components/OptionsModal/SyncPane.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import { Clearfix, Col, Table, Checkbox } from 'react-bootstrap';
+import { Alert, Clearfix, Col, Table, Checkbox } from 'react-bootstrap';
 
 import syncIsSupported from 'utils/syncIsSupported';
 import replicateStorage from 'utils/replicateStorage';
@@ -88,10 +88,10 @@ function SyncPane(props) {
                     Firefox to Chrome and vice versa does not work,
                     use export/import instead.
                   </p>
-                  <p>
-                    NOTE: Data is stored unencrypted, so do not enable if you
-                    do not trust your browser vendor with your data
-                  </p>
+                  <Alert bsStyle="warning">
+                    Data is stored unencrypted, so do not enable if you
+                    do not trust your browser vendor with your data!
+                  </Alert>
                 </Checkbox>
               </td>
             </tr>

--- a/src/components/OptionsModal/index.js
+++ b/src/components/OptionsModal/index.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Tabs, Tab } from 'react-bootstrap';
 
+import Fonticon from 'components/Fonticon';
+
 import TemplateOptionsPane from './TemplateOptionsPane';
 import GeneralOptionsPane from './GeneralOptionsPane';
 import SyncPane from './SyncPane';
 import ImportPane from './ImportPane';
 import ExportPane from './ExportPane';
-
-import Fonticon from 'components/Fonticon';
 
 export default class OptionsModalBody extends React.Component {
   constructor(props) {
@@ -25,44 +25,52 @@ export default class OptionsModalBody extends React.Component {
         onSelect={activeTab => this.setState({ activeTab })}
         id="OptionTabs"
       >
-        <Tab eventKey={0} title={
-          <span>
+        <Tab
+          eventKey={0} title={<span>
             <Fonticon icon="link" />
             <span>URL Templates</span>
-          </span>
-        }>
+          </span>}
+        >
           <TemplateOptionsPane />
         </Tab>
-        <Tab eventKey={1} title={
-          <span>
-            <Fonticon icon="cogs" />
-            <span>Options</span>
-          </span>
-        }>
+        <Tab
+          eventKey={1} title={
+            <span>
+              <Fonticon icon="cogs" />
+              <span>Options</span>
+            </span>
+        }
+        >
           <GeneralOptionsPane />
         </Tab>
-        <Tab eventKey={2} title={
-          <span>
-            <Fonticon icon="refresh" />
-            <span>Sync</span>
-          </span>
-        }>
+        <Tab
+          eventKey={2} title={
+            <span>
+              <Fonticon icon="refresh" />
+              <span>Sync</span>
+            </span>
+        }
+        >
           <SyncPane />
         </Tab>
-        <Tab eventKey={3} title={
-          <span>
-            <Fonticon icon="download" />
-            <span>Import data</span>
-          </span>
-        }>
+        <Tab
+          eventKey={3} title={
+            <span>
+              <Fonticon icon="download" />
+              <span>Import data</span>
+            </span>
+        }
+        >
           <ImportPane />
         </Tab>
-        <Tab eventKey={4} title={
-          <span>
-            <Fonticon icon="upload" />
-            <span>Export data</span>
-          </span>
-        }>
+        <Tab
+          eventKey={4} title={
+            <span>
+              <Fonticon icon="upload" />
+              <span>Export data</span>
+            </span>
+        }
+        >
           <ExportPane />
         </Tab>
       </Tabs>

--- a/src/components/OptionsModal/index.js
+++ b/src/components/OptionsModal/index.js
@@ -7,6 +7,8 @@ import SyncPane from './SyncPane';
 import ImportPane from './ImportPane';
 import ExportPane from './ExportPane';
 
+import Fonticon from 'components/Fonticon';
+
 export default class OptionsModalBody extends React.Component {
   constructor(props) {
     super(props);
@@ -23,19 +25,44 @@ export default class OptionsModalBody extends React.Component {
         onSelect={activeTab => this.setState({ activeTab })}
         id="OptionTabs"
       >
-        <Tab eventKey={0} title="URL Templates">
+        <Tab eventKey={0} title={
+          <span>
+            <Fonticon icon="link" />
+            <span>URL Templates</span>
+          </span>
+        }>
           <TemplateOptionsPane />
         </Tab>
-        <Tab eventKey={1} title="Options">
+        <Tab eventKey={1} title={
+          <span>
+            <Fonticon icon="cogs" />
+            <span>Options</span>
+          </span>
+        }>
           <GeneralOptionsPane />
         </Tab>
-        <Tab eventKey={2} title="Sync">
+        <Tab eventKey={2} title={
+          <span>
+            <Fonticon icon="refresh" />
+            <span>Sync</span>
+          </span>
+        }>
           <SyncPane />
         </Tab>
-        <Tab eventKey={3} title="Import data">
+        <Tab eventKey={3} title={
+          <span>
+            <Fonticon icon="download" />
+            <span>Import data</span>
+          </span>
+        }>
           <ImportPane />
         </Tab>
-        <Tab eventKey={4} title="Export data">
+        <Tab eventKey={4} title={
+          <span>
+            <Fonticon icon="upload" />
+            <span>Export data</span>
+          </span>
+        }>
           <ExportPane />
         </Tab>
       </Tabs>

--- a/test/components/__snapshots__/collapsable.test.js.snap
+++ b/test/components/__snapshots__/collapsable.test.js.snap
@@ -12,10 +12,14 @@ exports[`should render correctly 1`] = `
   >
     <h4>
       Test
-      <i
-        className="fa fa-angle-right"
-        role="presentation"
-      />
+      <div
+        className="jsiZnw clearfix"
+      >
+        <i
+          className="fa fa-angle-right"
+          role="presentation"
+        />
+      </div>
     </h4>
   </button>
   <div

--- a/test/components/__snapshots__/collections.test.js.snap
+++ b/test/components/__snapshots__/collections.test.js.snap
@@ -29,10 +29,14 @@ exports[`Collection component should match the previous snapshot 1`] = `
             Change name
           </span>
         </div>
-        <i
-          className="fa fa-pencil"
-          role="presentation"
-        />
+        <div
+          className="jsiZnw clearfix"
+        >
+          <i
+            className="fa fa-pencil"
+            role="presentation"
+          />
+        </div>
       </button>
       <button
         className="pull-right exyKyC"
@@ -52,10 +56,14 @@ exports[`Collection component should match the previous snapshot 1`] = `
             Delete
           </span>
         </div>
-        <i
-          className="fa fa-trash"
-          role="presentation"
-        />
+        <div
+          className="jsiZnw clearfix"
+        >
+          <i
+            className="fa fa-trash"
+            role="presentation"
+          />
+        </div>
       </button>
       <hr />
     </span>
@@ -94,10 +102,14 @@ exports[`Collection component should match the previous snapshot 1`] = `
                       Toggle edit
                     </span>
                   </div>
-                  <i
-                    className="fa fa-cog"
-                    role="presentation"
-                  />
+                  <div
+                    className="jsiZnw clearfix"
+                  >
+                    <i
+                      className="fa fa-cog"
+                      role="presentation"
+                    />
+                  </div>
                 </button>
                 <button
                   className="exyKyC"
@@ -117,10 +129,14 @@ exports[`Collection component should match the previous snapshot 1`] = `
                       Minimize
                     </span>
                   </div>
-                  <i
-                    className="fa fa-minus"
-                    role="presentation"
-                  />
+                  <div
+                    className="jsiZnw clearfix"
+                  >
+                    <i
+                      className="fa fa-minus"
+                      role="presentation"
+                    />
+                  </div>
                 </button>
               </div>
               <div
@@ -173,10 +189,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
             Add new collection
           </span>
         </div>
-        <i
-          className="fa fa-plus"
-          role="presentation"
-        />
+        <div
+          className="jsiZnw clearfix"
+        >
+          <i
+            className="fa fa-plus"
+            role="presentation"
+          />
+        </div>
       </button>
     </span>
   </div>
@@ -214,10 +234,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                   Change name
                 </span>
               </div>
-              <i
-                className="fa fa-pencil"
-                role="presentation"
-              />
+              <div
+                className="jsiZnw clearfix"
+              >
+                <i
+                  className="fa fa-pencil"
+                  role="presentation"
+                />
+              </div>
             </button>
             <button
               className="pull-right exyKyC"
@@ -237,10 +261,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                   Delete
                 </span>
               </div>
-              <i
-                className="fa fa-trash"
-                role="presentation"
-              />
+              <div
+                className="jsiZnw clearfix"
+              >
+                <i
+                  className="fa fa-trash"
+                  role="presentation"
+                />
+              </div>
             </button>
             <hr />
           </span>
@@ -279,10 +307,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Toggle edit
                           </span>
                         </div>
-                        <i
-                          className="fa fa-cog"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-cog"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                       <button
                         className="exyKyC"
@@ -302,10 +334,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Minimize
                           </span>
                         </div>
-                        <i
-                          className="fa fa-minus"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-minus"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                     </div>
                     <div
@@ -357,10 +393,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                   Change name
                 </span>
               </div>
-              <i
-                className="fa fa-pencil"
-                role="presentation"
-              />
+              <div
+                className="jsiZnw clearfix"
+              >
+                <i
+                  className="fa fa-pencil"
+                  role="presentation"
+                />
+              </div>
             </button>
             <button
               className="pull-right exyKyC"
@@ -380,10 +420,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                   Delete
                 </span>
               </div>
-              <i
-                className="fa fa-trash"
-                role="presentation"
-              />
+              <div
+                className="jsiZnw clearfix"
+              >
+                <i
+                  className="fa fa-trash"
+                  role="presentation"
+                />
+              </div>
             </button>
             <hr />
           </span>
@@ -422,10 +466,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Toggle edit
                           </span>
                         </div>
-                        <i
-                          className="fa fa-cog"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-cog"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                       <button
                         className="exyKyC"
@@ -445,10 +493,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Minimize
                           </span>
                         </div>
-                        <i
-                          className="fa fa-minus"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-minus"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                     </div>
                     <div
@@ -498,10 +550,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Toggle edit
                           </span>
                         </div>
-                        <i
-                          className="fa fa-cog"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-cog"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                       <button
                         className="exyKyC"
@@ -521,10 +577,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Minimize
                           </span>
                         </div>
-                        <i
-                          className="fa fa-minus"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-minus"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                     </div>
                     <div
@@ -574,10 +634,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Toggle edit
                           </span>
                         </div>
-                        <i
-                          className="fa fa-cog"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-cog"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                       <button
                         className="exyKyC"
@@ -597,10 +661,14 @@ exports[`Collections component should match the previous snapshot 1`] = `
                             Minimize
                           </span>
                         </div>
-                        <i
-                          className="fa fa-minus"
-                          role="presentation"
-                        />
+                        <div
+                          className="jsiZnw clearfix"
+                        >
+                          <i
+                            className="fa fa-minus"
+                            role="presentation"
+                          />
+                        </div>
                       </button>
                     </div>
                     <div

--- a/test/components/__snapshots__/fonticon.test.js.snap
+++ b/test/components/__snapshots__/fonticon.test.js.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Fonticon matches the previous snapshot 1`] = `
-<i
-  className="fa fa-cog"
-  role="presentation"
-/>
+<div
+  className="jsiZnw clearfix"
+>
+  <i
+    className="fa fa-cog"
+    role="presentation"
+  />
+</div>
 `;

--- a/test/components/request/__snapshots__/BasicAuthField.test.js.snap
+++ b/test/components/request/__snapshots__/BasicAuthField.test.js.snap
@@ -12,10 +12,14 @@ exports[`BasicAuthField should match the previous snapshot 1`] = `
   >
     <h4>
       Basic auth
-      <i
-        className="fa fa-angle-right"
-        role="presentation"
-      />
+      <div
+        className="jsiZnw clearfix"
+      >
+        <i
+          className="fa fa-angle-right"
+          role="presentation"
+        />
+      </div>
     </h4>
   </button>
   <div

--- a/test/components/request/__snapshots__/BodyField.test.js.snap
+++ b/test/components/request/__snapshots__/BodyField.test.js.snap
@@ -12,10 +12,14 @@ exports[`BodyField should match the previous snapshot when !useFormData 1`] = `
   >
     <h4>
       Request body
-      <i
-        className="fa fa-angle-right"
-        role="presentation"
-      />
+      <div
+        className="jsiZnw clearfix"
+      >
+        <i
+          className="fa fa-angle-right"
+          role="presentation"
+        />
+      </div>
     </h4>
   </button>
   <div
@@ -111,10 +115,14 @@ exports[`BodyField should match the previous snapshot when bodyType is json 1`] 
   >
     <h4>
       Request body
-      <i
-        className="fa fa-angle-right"
-        role="presentation"
-      />
+      <div
+        className="jsiZnw clearfix"
+      >
+        <i
+          className="fa fa-angle-right"
+          role="presentation"
+        />
+      </div>
     </h4>
   </button>
   <div
@@ -188,10 +196,14 @@ exports[`BodyField should match the previous snapshot when bodyType is json 1`] 
               onClick={[Function]}
               type="button"
             >
-              <i
-                className="fa fa-plus"
-                role="presentation"
-              />
+              <div
+                className="jsiZnw clearfix"
+              >
+                <i
+                  className="fa fa-plus"
+                  role="presentation"
+                />
+              </div>
               Add parameter
             </button>
           </div>
@@ -214,10 +226,14 @@ exports[`BodyField should match the previous snapshot when bodyType is multipart
   >
     <h4>
       Request body
-      <i
-        className="fa fa-angle-right"
-        role="presentation"
-      />
+      <div
+        className="jsiZnw clearfix"
+      >
+        <i
+          className="fa fa-angle-right"
+          role="presentation"
+        />
+      </div>
     </h4>
   </button>
   <div
@@ -291,10 +307,14 @@ exports[`BodyField should match the previous snapshot when bodyType is multipart
               onClick={[Function]}
               type="button"
             >
-              <i
-                className="fa fa-plus"
-                role="presentation"
-              />
+              <div
+                className="jsiZnw clearfix"
+              >
+                <i
+                  className="fa fa-plus"
+                  role="presentation"
+                />
+              </div>
               Add parameter
             </button>
           </div>
@@ -317,10 +337,14 @@ exports[`BodyField should match the previous snapshot when bodyType is urlencode
   >
     <h4>
       Request body
-      <i
-        className="fa fa-angle-right"
-        role="presentation"
-      />
+      <div
+        className="jsiZnw clearfix"
+      >
+        <i
+          className="fa fa-angle-right"
+          role="presentation"
+        />
+      </div>
     </h4>
   </button>
   <div
@@ -394,10 +418,14 @@ exports[`BodyField should match the previous snapshot when bodyType is urlencode
               onClick={[Function]}
               type="button"
             >
-              <i
-                className="fa fa-plus"
-                role="presentation"
-              />
+              <div
+                className="jsiZnw clearfix"
+              >
+                <i
+                  className="fa fa-plus"
+                  role="presentation"
+                />
+              </div>
               Add parameter
             </button>
           </div>

--- a/test/components/request/__snapshots__/HeadersField.test.js.snap
+++ b/test/components/request/__snapshots__/HeadersField.test.js.snap
@@ -12,10 +12,14 @@ exports[`HeadersField should match the previous snapshot 1`] = `
   >
     <h4>
       Headers
-      <i
-        className="fa fa-angle-right"
-        role="presentation"
-      />
+      <div
+        className="jsiZnw clearfix"
+      >
+        <i
+          className="fa fa-angle-right"
+          role="presentation"
+        />
+      </div>
     </h4>
   </button>
   <div
@@ -103,10 +107,14 @@ exports[`HeadersField should match the previous snapshot 1`] = `
                 Remove header
               </span>
             </div>
-            <i
-              className="fa fa-trash"
-              role="presentation"
-            />
+            <div
+              className="jsiZnw clearfix"
+            >
+              <i
+                className="fa fa-trash"
+                role="presentation"
+              />
+            </div>
           </button>
         </div>
       </div>
@@ -188,10 +196,14 @@ exports[`HeadersField should match the previous snapshot 1`] = `
                 Remove header
               </span>
             </div>
-            <i
-              className="fa fa-trash"
-              role="presentation"
-            />
+            <div
+              className="jsiZnw clearfix"
+            >
+              <i
+                className="fa fa-trash"
+                role="presentation"
+              />
+            </div>
           </button>
         </div>
       </div>
@@ -273,10 +285,14 @@ exports[`HeadersField should match the previous snapshot 1`] = `
                 Remove header
               </span>
             </div>
-            <i
-              className="fa fa-trash"
-              role="presentation"
-            />
+            <div
+              className="jsiZnw clearfix"
+            >
+              <i
+                className="fa fa-trash"
+                role="presentation"
+              />
+            </div>
           </button>
         </div>
       </div>
@@ -293,10 +309,14 @@ exports[`HeadersField should match the previous snapshot 1`] = `
             onClick={[Function]}
             type="button"
           >
-            <i
-              className="fa fa-plus"
-              role="presentation"
-            />
+            <div
+              className="jsiZnw clearfix"
+            >
+              <i
+                className="fa fa-plus"
+                role="presentation"
+              />
+            </div>
             Add header
           </button>
         </div>

--- a/test/components/request/__snapshots__/request.test.js.snap
+++ b/test/components/request/__snapshots__/request.test.js.snap
@@ -34,10 +34,14 @@ exports[`should render correctly 1`] = `
             Add to collection
           </span>
         </div>
-        <i
-          className="fa fa-plus"
-          role="presentation"
-        />
+        <div
+          className="jsiZnw clearfix"
+        >
+          <i
+            className="fa fa-plus"
+            role="presentation"
+          />
+        </div>
       </button>
       <button
         className="pull-right exyKyC"
@@ -57,10 +61,14 @@ exports[`should render correctly 1`] = `
             Options
           </span>
         </div>
-        <i
-          className="fa fa-cog"
-          role="presentation"
-        />
+        <div
+          className="jsiZnw clearfix"
+        >
+          <i
+            className="fa fa-cog"
+            role="presentation"
+          />
+        </div>
       </button>
       <button
         className="pull-right hidden-xs exyKyC"
@@ -80,10 +88,14 @@ exports[`should render correctly 1`] = `
             Hide collections
           </span>
         </div>
-        <i
-          className="fa fa-expand"
-          role="presentation"
-        />
+        <div
+          className="jsiZnw clearfix"
+        >
+          <i
+            className="fa fa-expand"
+            role="presentation"
+          />
+        </div>
       </button>
     </div>
   </div>
@@ -259,10 +271,14 @@ exports[`should render correctly 1`] = `
         >
           <h4>
             Headers
-            <i
-              className="fa fa-angle-right"
-              role="presentation"
-            />
+            <div
+              className="jsiZnw clearfix"
+            >
+              <i
+                className="fa fa-angle-right"
+                role="presentation"
+              />
+            </div>
           </h4>
         </button>
         <div
@@ -285,10 +301,14 @@ exports[`should render correctly 1`] = `
                   onClick={[Function]}
                   type="button"
                 >
-                  <i
-                    className="fa fa-plus"
-                    role="presentation"
-                  />
+                  <div
+                    className="jsiZnw clearfix"
+                  >
+                    <i
+                      className="fa fa-plus"
+                      role="presentation"
+                    />
+                  </div>
                   Add header
                 </button>
               </div>
@@ -307,10 +327,14 @@ exports[`should render correctly 1`] = `
         >
           <h4>
             Basic auth
-            <i
-              className="fa fa-angle-right"
-              role="presentation"
-            />
+            <div
+              className="jsiZnw clearfix"
+            >
+              <i
+                className="fa fa-angle-right"
+                role="presentation"
+              />
+            </div>
           </h4>
         </button>
         <div
@@ -390,10 +414,14 @@ exports[`should render correctly 1`] = `
         >
           <h4>
             Request body
-            <i
-              className="fa fa-angle-right"
-              role="presentation"
-            />
+            <div
+              className="jsiZnw clearfix"
+            >
+              <i
+                className="fa fa-angle-right"
+                role="presentation"
+              />
+            </div>
           </h4>
         </button>
         <div
@@ -467,10 +495,14 @@ exports[`should render correctly 1`] = `
                     onClick={[Function]}
                     type="button"
                   >
-                    <i
-                      className="fa fa-plus"
-                      role="presentation"
-                    />
+                    <div
+                      className="jsiZnw clearfix"
+                    >
+                      <i
+                        className="fa fa-plus"
+                        role="presentation"
+                      />
+                    </div>
                     Add parameter
                   </button>
                 </div>

--- a/test/components/response/__snapshots__/loading.test.js.snap
+++ b/test/components/response/__snapshots__/loading.test.js.snap
@@ -4,9 +4,13 @@ exports[`Loading matches the previous snapshot 1`] = `
 <div
   className="text-center col-xs-12"
 >
-  <i
-    className="fa fa-gear fa-spin iKhhRu"
-    role="presentation"
-  />
+  <div
+    className="jsiZnw clearfix"
+  >
+    <i
+      className="fa fa-gear fa-spin iKhhRu"
+      role="presentation"
+    />
+  </div>
 </div>
 `;

--- a/test/components/response/__snapshots__/response.test.js.snap
+++ b/test/components/response/__snapshots__/response.test.js.snap
@@ -49,10 +49,14 @@ exports[`response component renders a result when given one 1`] = `
       >
         <h4>
           Headers
-          <i
-            className="fa fa-angle-right"
-            role="presentation"
-          />
+          <div
+            className="jsiZnw clearfix"
+          >
+            <i
+              className="fa fa-angle-right"
+              role="presentation"
+            />
+          </div>
         </h4>
       </button>
       <div


### PR DESCRIPTION
## UI improvements to Options modal

| Description | Before | After |
|-------------|--------|------|
| Highlight style preview is now in the same "section" as the dropdown that selects it, and the indentation is fixed | ![code-style-before](https://user-images.githubusercontent.com/4079034/143958483-3f3890a9-32ea-4225-85e0-fcb485ad31f5.PNG)  | ![code-style-after](https://user-images.githubusercontent.com/4079034/143958639-83c5cc1d-f05e-4c43-9bc2-3d3829b054ae.PNG) |
| Add warning style to sync tab when it discusses security of syncing; security matters deserve some visual attention | ![browser-sync-before](https://user-images.githubusercontent.com/4079034/143958660-e15c8a5e-2f51-4032-8f4b-f78926064e74.PNG) | ![browser-sync-after](https://user-images.githubusercontent.com/4079034/143958674-6d20da7a-4566-40c3-ba71-5243a244a6ba.PNG) |
| Options modal tabs now have icons to add visual clarity | ![tabs-before](https://user-images.githubusercontent.com/4079034/143959301-41f26fb2-c883-4ef7-a8c9-e6f9c8aeb6df.PNG)  | ![tabs-after](https://user-images.githubusercontent.com/4079034/143958699-547beb8b-e5e5-4858-890d-ba800a30ae89.PNG) |
| The ungrouped checkboxes in the Options menu now have a "Miscellaneous" label, so they're not randomly floating around | ![misc-before](https://user-images.githubusercontent.com/4079034/143958740-5c35e183-dc0a-4d47-b51d-8d9e679ef63c.PNG) | ![misc-after](https://user-images.githubusercontent.com/4079034/143958755-2fa05567-74ce-4960-aaa7-1ae639166d17.PNG) |
