### PR TITLE
Collections list changes

### DIFF
--- a/src/components/Collections/Collection.js
+++ b/src/components/Collections/Collection.js
@@ -153,11 +153,12 @@ function PanelHeader(props) {
         className="pull-right"
         onClick={() => {
           setModalData({
-            title: 'Goodbye collection',
-            body: `You are about to delete the collection "${name}". ` +
-              'Are you sure?',
+            title: 'Delete collection',
+            body: `Are you sure you want to permanently delete the collection: "${name}"? All requests saved under this collection will also be deleted.`,
             actions: [{
               text: 'Delete',
+              type: 'danger',
+              icon: 'trash',
               click() {
                 deleteCollection(collectionId);
                 removeModal();

--- a/src/components/Collections/Collection.js
+++ b/src/components/Collections/Collection.js
@@ -4,8 +4,10 @@ import { findDOMNode } from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import { Collapse } from 'react-bootstrap';
 import flow from 'lodash.flow';
+import classNames from 'classnames';
 
 import IconButton from 'components/IconButton';
+import Fonticon from 'components/Fonticon';
 import * as CollectionsActions from 'store/collections/actions';
 import * as ModalActions from 'store/modal/actions';
 import requestPropType from 'propTypes/request';
@@ -129,6 +131,12 @@ function PanelHeader(props) {
             toggleCollapsed(index);
           }}
         >
+          <Fonticon
+            icon="angle-right"
+            className={classNames({
+              'fa-rotate-90': !minimized,
+            })}
+          />
           {name}
         </h3>
       )}

--- a/src/components/Collections/StyledComponents.js
+++ b/src/components/Collections/StyledComponents.js
@@ -50,11 +50,9 @@ export const StyledCollectionHeader = styled.span`
   input {
     width: 130px;
   }
-  ${props => props.minimized && css`
-    h3 {
-      font-style: italic;
-    }
-  `}
+  i.fa {
+    margin-right: 4px;
+  }
 `;
 
 export const StyledRequest = styled.div`

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -2,6 +2,8 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Modal, Button } from 'react-bootstrap';
 
+import Fonticon from 'components/Fonticon';
+
 import modalPropTypes from 'propTypes/modal';
 import * as Actions from 'store/modal/actions';
 
@@ -33,9 +35,11 @@ function ModalComponent({ modal, removeModal, clearModalData }) {
         {modal.actions && modal.actions.map((action, index) => (
           <Button
             key={index}
+            bsStyle={action.type || 'default'}
             data-dismiss="modal"
             onClick={action.click}
           >
+            {action.icon && <Fonticon icon={action.icon} />}
             {action.text}
           </Button>
         ))}

--- a/src/propTypes/modal.js
+++ b/src/propTypes/modal.js
@@ -10,6 +10,8 @@ export const modalShape = {
   cancelClick: func,
   actions: arrayOf(shape({
     text: string.isRequired,
+    type: string,
+    icon: string,
     click: func.isRequired,
   })),
 };

--- a/test/components/__snapshots__/collections.test.js.snap
+++ b/test/components/__snapshots__/collections.test.js.snap
@@ -6,11 +6,16 @@ exports[`Collection component should match the previous snapshot 1`] = `
     className="gRaYYP"
   >
     <span
-      className="drgkCg"
+      className="gBchMk"
     >
       <h3
         onClick={[Function]}
-      />
+      >
+        <i
+          className="fa fa-angle-right fa-rotate-90"
+          role="presentation"
+        />
+      </h3>
       <button
         className="pull-right exyKyC"
         onClick={[Function]}
@@ -189,11 +194,15 @@ exports[`Collections component should match the previous snapshot 1`] = `
           className="gRaYYP"
         >
           <span
-            className="cznwYF"
+            className="gBchMk"
           >
             <h3
               onClick={[Function]}
             >
+              <i
+                className="fa fa-angle-right"
+                role="presentation"
+              />
               Collection
             </h3>
             <button
@@ -332,11 +341,15 @@ exports[`Collections component should match the previous snapshot 1`] = `
           className="gRaYYP"
         >
           <span
-            className="cznwYF"
+            className="gBchMk"
           >
             <h3
               onClick={[Function]}
             >
+              <i
+                className="fa fa-angle-right"
+                role="presentation"
+              />
               Collection 2
             </h3>
             <button


### PR DESCRIPTION
## UI improvements to Collections list

| Description | Before | After |
|-------------|--------|------|
| Collections use chevron arrows to indicate minimized status, rather than italic font, for consistency with other collapsible items | ![collapse-collection-before](https://user-images.githubusercontent.com/4079034/143959679-5fc1c3bc-3375-47a7-bd22-0c554f23b9d6.PNG) | ![collapse-collection-after](https://user-images.githubusercontent.com/4079034/143959685-e9529f06-3fa4-47f9-b7c6-75daf99a3127.PNG) |
| Delete collection modal title and body contents have been revised to improve clarity, and the delete button is red with a trash icon to improve visual indication that its action is destructive, and to differentiate it from the close button | ![delete-collection-before](https://user-images.githubusercontent.com/4079034/143959696-5b6e964b-ae28-4a59-87d8-5cdafe8c2138.PNG) | ![delete-collection-after](https://user-images.githubusercontent.com/4079034/143959709-e3f5e691-27b5-4d67-8a31-23da5daedc0e.PNG) |