### PR TITLE
Enforce minimum value of zero on max history size

### DIFF
--- a/src/components/OptionsModal/GeneralOptionsPane.js
+++ b/src/components/OptionsModal/GeneralOptionsPane.js
@@ -82,14 +82,10 @@ function GeneralOptionsPane({ options, updateOption }) {
                     min="0"
                     value={options.get('historySize', DEFAULT_HISTORY_SIZE)}
                     onChange={e => {
-                      try {
-                        let value = parseInt(e.target.value, 10);
-                        if (value < 0) value = 0; // prevents manually typing negative value
-                        updateOption('historySize', value);
-                      } catch (parseIntException) {
-                        // Ignore any attempts to type an invalid value,
-                        // like letters, or a negative sign
-                      }
+                      const value = e.target.valueAsNumber;
+                      // Prevent invalid input
+                      if (isNaN(value)) return;
+                      updateOption('historySize', value >= 0 ? value : 0);
                     }}
                   />
                 </FormGroup>

--- a/src/components/OptionsModal/GeneralOptionsPane.js
+++ b/src/components/OptionsModal/GeneralOptionsPane.js
@@ -79,9 +79,17 @@ function GeneralOptionsPane({ options, updateOption }) {
                   </ControlLabel>
                   <FormControl
                     type="number"
+                    min="0"
                     value={options.get('historySize', DEFAULT_HISTORY_SIZE)}
                     onChange={e => {
-                      updateOption('historySize', e.target.value);
+                      try {
+                        let value = parseInt(e.target.value, 10);
+                        if (value < 0) value = 0; // prevents manually typing negative value
+                        updateOption('historySize', value);
+                      } catch (parseIntException) {
+                        // Ignore any attempts to type an invalid value,
+                        // like letters, or a negative sign
+                      }
                     }}
                   />
                 </FormGroup>

--- a/src/store/history/reducer.js
+++ b/src/store/history/reducer.js
@@ -33,7 +33,8 @@ export default function (state = initialState, action) {
     case PRUNE_HISTORY:
       return state
         .update('data', history => (
-          history.slice(0, action.historySize)
+          // Max history size cannot go below zero
+          history.slice(0, action.historySize >= 0 ? action.historySize : 0)
         ));
 
     case DELETE_ITEM:


### PR DESCRIPTION
## Maximum history size minimum value bug
Resolves an issue where the user can specify a maximum history size that goes negative, e.g. `historySize = -5`.

This is problematic not just for aesthetics, but because the fetching-history logic uses `.slice(0, historySize)`, so a negative history size will yield results.

Closes #217 