### PR TITLE
Make syntax highlighting size limit configurable

### DIFF
--- a/src/components/OptionsModal/GeneralOptionsPane.js
+++ b/src/components/OptionsModal/GeneralOptionsPane.js
@@ -5,7 +5,7 @@ import Highlight from 'react-highlight';
 import { Col, Table, FormGroup, FormControl, ControlLabel, Checkbox } from 'react-bootstrap';
 
 import * as Actions from 'store/options/actions';
-import { THEMES, HIGHLIGHT_STYLES, DEFAULT_HISTORY_SIZE } from 'constants/constants';
+import { THEMES, HIGHLIGHT_STYLES, DEFAULT_HISTORY_SIZE, DEFAULT_SYNTAX_HIGHLIGHTING_RESPONSE_SIZE } from 'constants/constants';
 
 import { StyledGeneralOptions } from './StyledComponents';
 
@@ -67,6 +67,26 @@ function GeneralOptionsPane({ options, updateOption }) {
                   <Highlight className="json">
                     {CodeHighlightPreviewText}
                   </Highlight>
+                </FormGroup>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <FormGroup>
+                  <ControlLabel>
+                    Max syntax highlighting size (KB)
+                  </ControlLabel>
+                  <FormControl
+                    type="number"
+                    min="0"
+                    value={options.get('syntaxHighlightingMaxSize', DEFAULT_SYNTAX_HIGHLIGHTING_RESPONSE_SIZE)}
+                    onChange={e => {
+                      const highlightSizeKB = e.target.valueAsNumber;
+                      if (isNaN(highlightSizeKB)) return;
+                      updateOption('syntaxHighlightingMaxSize', highlightSizeKB >= 0 ? highlightSizeKB : 0);
+                    }}
+                  />
                 </FormGroup>
               </td>
             </tr>

--- a/src/components/Response/Response.js
+++ b/src/components/Response/Response.js
@@ -5,7 +5,7 @@ import Highlight from 'react-highlight';
 import formatXml from 'xml-formatter';
 
 import * as Actions from 'store/request/actions';
-import { isDisabledHighlighting, isWrapResponse } from 'store/options/selectors';
+import { isDisabledHighlighting, getSyntaxHighlightingMaxSize, isWrapResponse } from 'store/options/selectors';
 import responsePropTypes, { responseShape } from 'propTypes/response';
 import getContentType from 'utils/contentType';
 import approximateSizeFromLength from 'utils/approximateSizeFromLength';
@@ -33,6 +33,7 @@ export function Response(props) {
   const {
     response,
     highlightingDisabled,
+    syntaxHighlightingMaxSize,
     wrapResponse,
     redirectChain,
     interceptedResponse,
@@ -92,17 +93,18 @@ export function Response(props) {
       <Headers headers={interceptedResponse.responseHeaders} />
       {type.html && <RenderedResponse html={body} />}
 
-      {!highlightingDisabled && contentSize < 20000
+      {!highlightingDisabled && contentSize < (syntaxHighlightingMaxSize * 1000)
         ? (
           <Highlight>
             {body}
           </Highlight>
         ) : (
           <span>
-            {contentSize >= 20000 && (
+            {contentSize >= (syntaxHighlightingMaxSize * 1000) && (
               <Alert bsStyle="warning">
-                The size of the response is greater than 20KB, syntax
-                highlighting has been disabled for performance reasons.
+                The response size exceeds {syntaxHighlightingMaxSize} KB. Syntax highlighting
+                has been disabled for performance reasons. This value is configurable in the
+                options menu.
               </Alert>
             )}
 
@@ -119,6 +121,7 @@ export function Response(props) {
 Response.propTypes = {
   response: responsePropTypes,
   highlightingDisabled: PropTypes.bool.isRequired,
+  syntaxHighlightingMaxSize: PropTypes.number.isRequired,
   wrapResponse: PropTypes.bool.isRequired,
   redirectChain: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   interceptedResponse: PropTypes.shape({}),
@@ -126,6 +129,7 @@ Response.propTypes = {
 
 const mapStateToProps = state => ({
   highlightingDisabled: isDisabledHighlighting(state),
+  syntaxHighlightingMaxSize: getSyntaxHighlightingMaxSize(state),
   wrapResponse: isWrapResponse(state),
 });
 

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -54,6 +54,14 @@ export const DEFAULT_SELECTED_COLLECTION = '0';
 export const DEFAULT_HISTORY_SIZE = 10;
 
 /**
+ * The default maximum response size for which
+ * syntax highlighting is enabled (kilobytes). Any
+ * value greater than this will have highlighting
+ * turned off for performance reasons.
+ */
+export const DEFAULT_SYNTAX_HIGHLIGHTING_RESPONSE_SIZE = 20;
+
+/**
  * This is the request used to initialize the
  * request panel. This can be either on
  * application load or on request reset.

--- a/src/store/options/selectors.js
+++ b/src/store/options/selectors.js
@@ -23,6 +23,11 @@ export const getHighlightStyle = createSelector(
   options => options && options.getIn(['options', 'highlightStyle'], 'default'),
 );
 
+export const getSyntaxHighlightingMaxSize = createSelector(
+  [getOptions],
+  options => options && options.getIn(['options', 'syntaxHighlightingMaxSize'], 20),
+);
+
 export const getCollectionsMinimized = createSelector(
   [getOptions],
   options => options && options.getIn(['options', 'collectionsMinimized'], false),

--- a/test/components/response/__snapshots__/response.test.js.snap
+++ b/test/components/response/__snapshots__/response.test.js.snap
@@ -68,6 +68,13 @@ exports[`response component renders a result when given one 1`] = `
         />
       </div>
     </div>
+    <span>
+      <code>
+        <pre>
+          Some long body
+        </pre>
+      </code>
+    </span>
   </div>
 </div>
 `;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4079034/144661534-ffd36bd0-7705-40ca-acab-95897f8f323e.png)

![image](https://user-images.githubusercontent.com/4079034/144661616-d78dfd45-4a7a-4422-beb9-aaa7efe6b948.png)


The previous value was hard-coded at 20KB, but the user can now configure this limit

Syntax highlighting incurs a performance penalty, but that will be dependent on user preference

Closes #171
Closes #74